### PR TITLE
New graph: Exercises type and count per course and minor fixes

### DIFF
--- a/frontend/src/components/DownloadModal.tsx
+++ b/frontend/src/components/DownloadModal.tsx
@@ -51,7 +51,10 @@ export default function DownloadModal(props: DownloadModalProps) {
   const handleOk = () => {
     setDownloading(true);
 
-    let messageReturn = message.loading({ content: "Preparing download..." });
+    let messageReturn = message.loading({
+      content: "Preparing download...",
+      duration: 0,
+    });
 
     prepareDownloadService(
       props.consumer,
@@ -95,6 +98,7 @@ export default function DownloadModal(props: DownloadModalProps) {
         setDownloading(false);
       })
       .catch((err) => {
+        messageReturn();
         console.log("Error while downloading exercise", err);
         message.error({
           content: "Error downloading",

--- a/frontend/src/containers/Home/index.tsx
+++ b/frontend/src/containers/Home/index.tsx
@@ -11,7 +11,7 @@ import { CourseInterface } from "src/Interfaces/CourseInterface";
 import { getConsumersListService } from "src/services/consumers";
 import {
   getCourseDetailsService,
-  getCourseExerciseTypesCountsService,
+  getCourseExerciseTypesCountsEventsService,
   getCoursesListService,
   getCourseSubmissionsOverTimeService,
 } from "src/services/courses";
@@ -202,7 +202,7 @@ const Home = (): ReactElement => {
 
   const fetchCourseExerciseTypesCount = () => {
     setCourseExerciseTypesCountLoading(true);
-    let result = getCourseExerciseTypesCountsService(
+    let result = getCourseExerciseTypesCountsEventsService(
       selectedConsumer,
       selectedCourse,
       selectedActor

--- a/frontend/src/containers/Home/index.tsx
+++ b/frontend/src/containers/Home/index.tsx
@@ -12,6 +12,7 @@ import { getConsumersListService } from "src/services/consumers";
 import {
   getCourseDetailsService,
   getCourseExerciseTypesCountsEventsService,
+  getCourseExerciseTypesCountService,
   getCoursesListService,
   getCourseSubmissionsOverTimeService,
 } from "src/services/courses";
@@ -62,6 +63,14 @@ const Home = (): ReactElement => {
     courseSubmissionsOverTimeLoading,
     setCourseSubmissionsOverTimeLoading,
   ] = useState<boolean>(true);
+
+  const [
+    courseExerciseTypesCountEventsLoading,
+    setCourseExerciseTypesCountEventsLoading,
+  ] = useState<boolean>(true);
+
+  const [courseExerciseTypesCountEvents, setCourseExerciseTypesCountEvents] =
+    useState<any>({});
 
   const [courseExerciseTypesCountLoading, setCourseExerciseTypesCountLoading] =
     useState<boolean>(true);
@@ -200,9 +209,29 @@ const Home = (): ReactElement => {
       });
   };
 
+  const fetchCourseExerciseTypesCountEvents = () => {
+    setCourseExerciseTypesCountEventsLoading(true);
+    let result = getCourseExerciseTypesCountsEventsService(
+      selectedConsumer,
+      selectedCourse,
+      selectedActor
+    );
+    result
+      .then((res) => {
+        setCourseExerciseTypesCountEvents(res);
+
+        setCourseExerciseTypesCountEventsLoading(false);
+      })
+      .catch((err) => {
+        console.log(err);
+
+        setCourseExerciseTypesCountEventsLoading(false);
+      });
+  };
+
   const fetchCourseExerciseTypesCount = () => {
     setCourseExerciseTypesCountLoading(true);
-    let result = getCourseExerciseTypesCountsEventsService(
+    let result = getCourseExerciseTypesCountService(
       selectedConsumer,
       selectedCourse,
       selectedActor
@@ -252,6 +281,7 @@ const Home = (): ReactElement => {
       }
 
       //fetchCourseSubmissionsOverTime();
+      //fetchCourseExerciseTypesCountEvents();
       //fetchCourseExerciseTypesCount();
     }
   }, [selectedCourse, selectedActor]);
@@ -445,6 +475,7 @@ const Home = (): ReactElement => {
           onConfirm={() => {
             // fetchCourse();
             fetchCourseSubmissionsOverTime();
+            fetchCourseExerciseTypesCountEvents();
             fetchCourseExerciseTypesCount();
             setShowCourseStats(true);
           }}
@@ -482,11 +513,27 @@ const Home = (): ReactElement => {
             </Col>
             <Col md={24} lg={24} xl={12} span={12}>
               <div className="shadow-bordered">
+                {!courseExerciseTypesCountEventsLoading ? (
+                  <ExerciseTypesGraph
+                    loading={courseExerciseTypesCountEventsLoading}
+                    data={courseExerciseTypesCountEvents}
+                    title={"Exercise types and number of events"}
+                  />
+                ) : (
+                  <Spin />
+                )}
+              </div>
+            </Col>
+          </Row>
+          <Divider></Divider>
+          <Row gutter={[24, 24]}>
+            <Col md={24} lg={24} xl={12} span={12}>
+              <div className="shadow-bordered">
                 {!courseExerciseTypesCountLoading ? (
                   <ExerciseTypesGraph
                     loading={courseExerciseTypesCountLoading}
                     data={courseExerciseTypesCount}
-                    title={"Exercise types and number of events"}
+                    title={"Exercise types and count"}
                   />
                 ) : (
                   <Spin />

--- a/frontend/src/services/courses.ts
+++ b/frontend/src/services/courses.ts
@@ -3,7 +3,7 @@ import {
   API_GET_COURSES,
   API_GET_COURSE,
   API_GET_COURSE_SUBMISSIONS_BY_TIME,
-  API_GET_COURSE_EXERCISE_TYPES_COUNTS,
+  API_GET_COURSE_EXERCISE_TYPES_COUNTS_EVENTS,
   API_GET_ALL_COURSES_ADMIN,
 } from "src/utils/constants";
 
@@ -48,7 +48,7 @@ export const getCourseSubmissionsOverTimeService = async (
 };
 
 // Get Course Exercise Types and their records/events counts
-export const getCourseExerciseTypesCountsService = async (
+export const getCourseExerciseTypesCountsEventsService = async (
   consumer: string,
   courseId: string,
   actor?: string
@@ -60,7 +60,7 @@ export const getCourseExerciseTypesCountsService = async (
   }
 
   const response = await axios.get(
-    `${API_GET_COURSE_EXERCISE_TYPES_COUNTS}${queryString}`
+    `${API_GET_COURSE_EXERCISE_TYPES_COUNTS_EVENTS}${queryString}`
   );
 
   return response.data.result;

--- a/frontend/src/services/courses.ts
+++ b/frontend/src/services/courses.ts
@@ -4,6 +4,7 @@ import {
   API_GET_COURSE,
   API_GET_COURSE_SUBMISSIONS_BY_TIME,
   API_GET_COURSE_EXERCISE_TYPES_COUNTS_EVENTS,
+  API_GET_COURSE_EXERCISE_TYPES_COUNT,
   API_GET_ALL_COURSES_ADMIN,
 } from "src/utils/constants";
 
@@ -61,6 +62,25 @@ export const getCourseExerciseTypesCountsEventsService = async (
 
   const response = await axios.get(
     `${API_GET_COURSE_EXERCISE_TYPES_COUNTS_EVENTS}${queryString}`
+  );
+
+  return response.data.result;
+};
+
+// Get Course Exercise Types and their count
+export const getCourseExerciseTypesCountService = async (
+  consumer: string,
+  courseId: string,
+  actor?: string
+) => {
+  // Construct query string
+  let queryString = `/${courseId}?consumer=${consumer}`;
+  if (actor) {
+    queryString += `&filters[xAPI.actor.name]=${actor}`;
+  }
+
+  const response = await axios.get(
+    `${API_GET_COURSE_EXERCISE_TYPES_COUNT}${queryString}`
   );
 
   return response.data.result;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -16,8 +16,8 @@ export const API_GET_COURSE = "records/course";
 export const API_GET_COURSE_SUBMISSIONS_BY_TIME =
   "records/courseSubmissionsOverTime";
 
-export const API_GET_COURSE_EXERCISE_TYPES_COUNTS =
-  "records/courseExerciseTypesAndCount";
+export const API_GET_COURSE_EXERCISE_TYPES_COUNTS_EVENTS =
+  "records/courseExerciseTypesAndCountEvents";
 
 export const API_GET_EXERCISES = "records/exercises";
 export const API_GET_EXERCISE_DETAILS = "records/exerciseDetails";

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -19,6 +19,9 @@ export const API_GET_COURSE_SUBMISSIONS_BY_TIME =
 export const API_GET_COURSE_EXERCISE_TYPES_COUNTS_EVENTS =
   "records/courseExerciseTypesAndCountEvents";
 
+export const API_GET_COURSE_EXERCISE_TYPES_COUNT =
+  "records/courseExerciseTypesCount";
+
 export const API_GET_EXERCISES = "records/exercises";
 export const API_GET_EXERCISE_DETAILS = "records/exerciseDetails";
 export const API_GET_EXERCISE_SUBMISSIONS_BY_TIME =

--- a/records.js
+++ b/records.js
@@ -46,7 +46,10 @@ router.get("/courses", getCourses);
 router.get("/course/:id", getCourse);
 
 router.get("/courseSubmissionsOverTime/:id", getCourseSubmissionsOverTime);
-router.get("/courseExerciseTypesAndCount/:id", getCourseExerciseTypesAndCount);
+router.get(
+  "/courseExerciseTypesAndCountEvents/:id",
+  getCourseExerciseTypesAndCountEvents
+);
 
 router.get("/prepareDownload", prepareDownload);
 router.post("/download", download);
@@ -1346,7 +1349,7 @@ async function getCourseSubmissionsOverTime(req, res, next) {
   }
 }
 
-async function getCourseExerciseTypesAndCount(req, res, next) {
+async function getCourseExerciseTypesAndCountEvents(req, res, next) {
   let courseId = req.params.id ? req.params.id : undefined;
 
   let consumer = req.query.consumer


### PR DESCRIPTION
- Added a new graph, which shows types and number of exercises per course
- Preparing download message popup doesn't go away until preparing is complete or is failed
- Fixed proper naming to existing service, endpoint graph which was showing exercises types and number of events per course