### PR TITLE
Add data source field to consumers & logout previous user when using magic link token

### DIFF
--- a/frontend/src/Interfaces/ConsumerInterface.ts
+++ b/frontend/src/Interfaces/ConsumerInterface.ts
@@ -4,4 +4,5 @@ export interface ConsumerInterface {
   name: string;
   picture?: string;
   createdAt?: Date;
+  dataSource?: string;
 }

--- a/frontend/src/containers/Consumers/CreateConsumer.tsx
+++ b/frontend/src/containers/Consumers/CreateConsumer.tsx
@@ -2,6 +2,8 @@ import Button from "antd/lib/button";
 import Drawer from "antd/lib/drawer";
 import Form from "antd/lib/form";
 import Input from "antd/lib/input";
+import Select from "antd/lib/select";
+import Option from "antd/lib/select";
 import notification from "antd/lib/notification";
 import { useEffect, useRef, useState } from "react";
 import { createConsumerService } from "src/services/consumers";
@@ -108,6 +110,33 @@ export default function CreateConsumer(props) {
             ]}
           >
             <Input />
+          </Form.Item>
+
+          <Form.Item
+            label="Data source"
+            name="dataSource"
+            rules={[
+              {
+                required: false,
+                message: "Please provide a data source of this consumer",
+                type: "string",
+                whitespace: true,
+              },
+            ]}
+          >
+            <Select
+              placeholder="Select a data source"
+              defaultValue={undefined || null}
+            >
+              <Option value={undefined}>Not specified</Option>
+              <Option value="openHPI Platform">openHPI Platform</Option>
+              <Option value="Moodle">Moodle</Option>
+              <Option value="Open edX">Open edX</Option>
+              <Option value="Wordpress">Wordpress</Option>
+              <Option value="Drupal">Drupal</Option>
+              <Option value="Joomla">Joomla</Option>
+              <Option value="Other">Other</Option>
+            </Select>
           </Form.Item>
 
           <Form.Item>

--- a/frontend/src/containers/Consumers/EditConsumer.tsx
+++ b/frontend/src/containers/Consumers/EditConsumer.tsx
@@ -2,6 +2,8 @@ import Button from "antd/lib/button";
 import Drawer from "antd/lib/drawer";
 import Form from "antd/lib/form";
 import Input from "antd/lib/input";
+import Select from "antd/lib/select";
+import Option from "antd/lib/select";
 import notification from "antd/lib/notification";
 import { useRef, useState } from "react";
 import { ConsumerInterface } from "src/Interfaces/ConsumerInterface";
@@ -102,6 +104,33 @@ export default function EditConsumer(props) {
             ]}
           >
             <Input />
+          </Form.Item>
+
+          <Form.Item
+            label="Data source"
+            name="dataSource"
+            rules={[
+              {
+                required: false,
+                message: "Please provide a data source of this consumer",
+                type: "string",
+                whitespace: true,
+              },
+            ]}
+          >
+            <Select
+              placeholder="Select a data source"
+              defaultValue={undefined || null}
+            >
+              <Option value={undefined}>Not specified</Option>
+              <Option value="openHPI Platform">openHPI Platform</Option>
+              <Option value="Moodle">Moodle</Option>
+              <Option value="Open edX">Open edX</Option>
+              <Option value="Wordpress">Wordpress</Option>
+              <Option value="Drupal">Drupal</Option>
+              <Option value="Joomla">Joomla</Option>
+              <Option value="Other">Other</Option>
+            </Select>
           </Form.Item>
 
           <Form.Item>

--- a/frontend/src/containers/Consumers/index.tsx
+++ b/frontend/src/containers/Consumers/index.tsx
@@ -162,6 +162,17 @@ const Consumers = (): React.ReactElement => {
     },
 
     {
+      title: "Data source",
+      dataIndex: "dataSource",
+      key: "dataSource",
+      // Responsive, show on bigger devices
+      responsive: ["xl", "xxl"],
+      render: (text, record: ConsumerInterface) => {
+        return record.dataSource || "Not specified";
+      },
+    },
+
+    {
       title: "Action",
       key: "action",
       render: (_, record: ConsumerInterface) => (

--- a/frontend/src/containers/Login/index.tsx
+++ b/frontend/src/containers/Login/index.tsx
@@ -5,7 +5,7 @@ import Button from "antd/lib/button";
 import { EyeInvisibleOutlined, EyeOutlined } from "@ant-design/icons";
 import { Link, useParams } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
-import { login, logout } from "../../redux/auth";
+import { login, logout, setGlobalLoading } from "../../redux/auth";
 import { ReactElement } from "react";
 import { Tooltip } from "antd";
 
@@ -24,7 +24,10 @@ const Login = (): ReactElement => {
 
   useEffect(() => {
     if (token) {
+      dispatch(setGlobalLoading(true));
+      dispatch(logout());
       dispatch(login({ magicToken: token }));
+      dispatch(setGlobalLoading(false));
     }
   }, [token, dispatch]);
 

--- a/frontend/src/utils/routeConstants.ts
+++ b/frontend/src/utils/routeConstants.ts
@@ -186,6 +186,18 @@ export const routeConstants = [
       exact: true,
     },
     layoutType: "auth",
+    authType: "only-authenticated",
+    component: Login,
+    menuItem: false,
+  },
+  {
+    showInSidebar: false,
+    title: "Login",
+    route: {
+      path: "/login-magic-token/:token",
+      exact: true,
+    },
+    layoutType: "auth",
     authType: "only-unauthenticated",
     component: Login,
     menuItem: false,


### PR DESCRIPTION
This pull request introduces a new dataSource field to the ConsumerInterface and adds a dataSource field to the consumer creation and editing forms. It also displays the dataSource information in the consumers table.

It also includes ability to log out previous user if a magic link is used to log in via the token